### PR TITLE
client can now get arrivals list from endpoint

### DIFF
--- a/lib/router.ex
+++ b/lib/router.ex
@@ -1,10 +1,17 @@
 defmodule Commuter.Router do
   use Plug.Router
+
   require Logger
+
+  alias Commuter.Station.Controller
 
   plug Plug.Logger
   plug :match
   plug :dispatch
+
+  def start_link do
+    {:ok, _} = Plug.Adapters.Cowboy.http(Commuter.Router, [])
+  end
 
   def init(opts) do
     opts
@@ -16,12 +23,16 @@ defmodule Commuter.Router do
     |> halt
   end
 
+  get "/stations/:station_id/:line_id/:direction" do
+    arrivals =
+      Commuter.Station.Controller.return_arrivals(station_id, line_id, direction)
+    conn
+    |> send_resp(200, arrivals)
+  end
+
   match _ do
     IO.inspect(conn.params)
     send_resp(conn, 404, "oops!")
   end
 
-  def start_link do
-    {:ok, _} = Plug.Adapters.Cowboy.http Commuter.Router, []
-  end
 end

--- a/lib/station/controller.ex
+++ b/lib/station/controller.ex
@@ -1,0 +1,30 @@
+defmodule Commuter.Station.Controller do
+  @moduledoc """
+  Handles client requests for station data.
+  """
+  alias Commuter.Train
+
+  def return_arrivals(station_id, line_id, direction) do
+    direction_atom = atomize_params(direction)
+
+    atomize_params({station_id, line_id})
+    |> Commuter.Station.get_arrivals
+    |> take_direction(direction_atom)
+    |> Poison.encode!
+  end
+
+  defp atomize_params({first, second}) do
+    "#{first}_#{second}" |> String.to_atom
+  end
+  defp atomize_params(one_string), do: String.to_atom(one_string)
+
+  defp take_direction(%Commuter.Station{} = station, direction) do
+    Map.get(station, direction)
+  end
+
+  defp only_distance_in_seconds(list_of_trains) do
+    list_of_trains
+    |> Enum.map(fn %Train{time_to_station: time} -> "#{time} secs" end)
+  end
+
+end

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -1,4 +1,4 @@
-defmodule CommuterRouterTest do
+defmodule RouterTest do
   use ExUnit.Case, async: true
   use Plug.Test
 

--- a/test/station/station_controller_test.exs
+++ b/test/station/station_controller_test.exs
@@ -1,0 +1,15 @@
+defmodule Commuter.Station.ControllerTest do
+  use ExUnit.Case
+
+  alias Commuter.Station.Controller
+
+  @tooting "940GZZLUTBC"
+  @northern "northern"
+  @direction "inbound"
+
+  test "returns a list of train structs" do
+    result = Controller.return_arrivals(@tooting, @northern, @direction)
+    assert is_list(result)
+    
+  end
+end

--- a/test/station/station_test.exs
+++ b/test/station/station_test.exs
@@ -1,22 +1,25 @@
 defmodule Commuter.Station.StationTest do
   use ExUnit.Case, async: true
   alias Commuter.Station
-  alias Commuter.Station.StationSupervisor
 
   @tooting "940GZZLUTBC"
+  @northern "northern"
+  @direction "inbound"
+
+  @process_id :"940GZZLUTBC_northern"
 
   test "returns a struct with two lists of trains" do
-    result = Station.get_arrivals
+    result = Station.get_arrivals(@process_id)
     %Station{inbound: inbound_list, outbound: outbound_list} = result
     assert is_list(inbound_list) && is_list(outbound_list)
   end
 
   test "the trains are all assigned to the correct direction's list" do
-    result = Station.get_arrivals
+    result = Station.get_arrivals(@process_id)
     Enum.each(result.inbound, fn %Commuter.Train{direction: direction} ->
       assert direction == "inbound" end)
     Enum.each(result.outbound, fn %Commuter.Train{direction: direction} ->
       assert direction == "outbound" end)
   end
-  
+
 end


### PR DESCRIPTION
as described -  this hooks up a really basic endpoint for a client to hit. 

When you visit `/stations/:station_id/:line_id/:direction`, this goes ahead and fetches live arrivals from TFL and returns the requested list of trains to the client as JSON.

