### PR TITLE
Tfl test sandbox

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,4 +27,4 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+    import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :commuter, :tfl_api, Commuter.Tfl

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :commuter, :tfl_api, Commuter.Tfl

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :commuter, :tfl_api, Commuter.Tfl.Mock

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -24,10 +24,7 @@ defmodule Commuter.Router do
   end
 
   get "/stations/:station_id/:line_id/:direction" do
-    arrivals =
-      Commuter.Station.Controller.return_arrivals(station_id, line_id, direction)
-    conn
-    |> send_resp(200, arrivals)
+    Controller.get_arrivals(conn)
   end
 
   match _ do

--- a/lib/station/controller.ex
+++ b/lib/station/controller.ex
@@ -4,27 +4,59 @@ defmodule Commuter.Station.Controller do
   """
   alias Commuter.Train
 
-  def return_arrivals(station_id, line_id, direction) do
-    direction_atom = atomize_params(direction)
+  @doc """
+  Fetches the station, line and direction params from the connection and tries
+  to call the corresponding process to retrieve arrivals data.
 
-    atomize_params({station_id, line_id})
-    |> Commuter.Station.get_arrivals
-    |> take_direction(direction_atom)
-    |> Poison.encode!
+  Sends a response back to the client.
+  """
+  def get_arrivals(%Plug.Conn{} = conn) do
+    conn
+    |> assign_arrival_params
+    |> lookup_process
   end
 
+  defp assign_arrival_params(%Plug.Conn{path_params: p} = conn) do
+    conn
+    |> Plug.Conn.assign(:pid, atomize_params({p["station_id"], p["line_id"]}))
+    |> Plug.Conn.assign(:direction, atomize_params(p["direction"]))
+  end
+
+  # atomize the params
   defp atomize_params({first, second}) do
     "#{first}_#{second}" |> String.to_atom
   end
   defp atomize_params(one_string), do: String.to_atom(one_string)
 
-  defp take_direction(%Commuter.Station{} = station, direction) do
+  defp lookup_process(%Plug.Conn{assigns: assigns} = conn) do
+    process_list = Process.registered
+    case Enum.member?(process_list, assigns.pid) do
+      false ->
+        Plug.Conn.resp(conn, 404, "NOT FOUND")
+      true ->
+        call_process(conn)
+    end
+  end
+
+  defp call_process(%Plug.Conn{assigns: assigns} = conn) do
+    assigns.pid
+    |> Commuter.Station.get_arrivals
+    |> take_direction_list(assigns.direction)
+    |> Poison.encode!
+    |> send_response(200, conn)
+  end
+
+  defp take_direction_list(%Commuter.Station{} = station, direction) do
     Map.get(station, direction)
   end
 
-  defp only_distance_in_seconds(list_of_trains) do
-    list_of_trains
-    |> Enum.map(fn %Train{time_to_station: time} -> "#{time} secs" end)
+  defp send_response(response_body, code, conn) do
+    Plug.Conn.resp(conn, code, response_body)
   end
+
+  # defp only_distance_in_seconds(list_of_trains) do
+  #   list_of_trains
+  #   |> Enum.map(fn %Train{time_to_station: time} -> "#{time} secs" end)
+  # end
 
 end

--- a/lib/station/controller.ex
+++ b/lib/station/controller.ex
@@ -2,7 +2,6 @@ defmodule Commuter.Station.Controller do
   @moduledoc """
   Handles client requests for station data.
   """
-  alias Commuter.Train
 
   @doc """
   Fetches the station, line and direction params from the connection and tries

--- a/lib/station/station_supervisor.ex
+++ b/lib/station/station_supervisor.ex
@@ -9,6 +9,10 @@ defmodule Commuter.Station.StationSupervisor do
     {:ok, _pid} = Supervisor.start_link(children, opts)
   end
 
+  def init(:ok) do
+    {:ok, []}
+  end
+
   defp create_all_workers(list_of_stations) do
     list_of_stations
     |> Enum.map( &(create_line_workers(&1)) )

--- a/lib/tfl/mock.ex
+++ b/lib/tfl/mock.ex
@@ -1,0 +1,152 @@
+defmodule Commuter.Tfl.Mock do
+  @moduledoc """
+  Provides a mock TFL server to allow tests to get quick data without calling
+  the real life TFL api.
+  """
+  @behaviour Commuter.Tfl
+
+  @doc """
+  A smoke screen - this will always return true because we don't need to
+  test the failure of a mock api call... Let it crash!!
+  """
+  def successful_response?(_response), do: true
+
+  def take_body(map), do: map.body
+
+  @doc """
+  Returns four stations:
+  - Clapham Junction
+  - Waterloo
+  - Tooting Bec
+  - Victoria
+  """
+  def retrieve_all_stations(_url \\ "fake") do
+    IO.puts "Using Mock TFL to get station list..."
+    [
+      %{
+        "commonName" => "Waterloo", "modes" => ["tube", "bus"],
+        "naptanId" => "940GZZLUWLO",
+        "lineModeGroups" => [%{"modeName" => "tube",
+                              "lineIdentifier" => [ "northern", "jubilee",
+                                                    "bakerloo", "waterloo-city"]},
+                            %{"modeName" => "bus",
+                              "lineIdentifier" => ["10"]}]
+      },
+      %{
+        "commonName" => "Tooting Bec", "modes" => ["tube"],
+        "naptanId" => "940GZZLUTBC",
+        "lineModeGroups" => [%{"modeName" => "tube",
+                              "lineIdentifier" => [ "northern"]},
+                            %{"modeName" => "bus",
+                              "lineIdentifier" => ["130"]}]
+      },
+      %{
+        "commonName" => "Victoria", "modes" => ["tube", "bus", "rail"],
+        "naptanId" => "940GZZLUVIC",
+        "lineModeGroups" => [%{"modeName" => "tube",
+                              "lineIdentifier" => [ "circle", "district",
+                                                    "victoria"]},
+                            %{"modeName" => "bus",
+                              "lineIdentifier" => ["N130"]}]
+      },
+      %{
+        "commonName" => "Clapham Junction", "modes" => ["rail", "bus"],
+        "naptanId" => "940GZZLUCLA",
+        "lineModeGroups" => [%{"modeName" => "bus",
+                              "lineIdentifier" => [ "N133", "100"]}]
+      }
+    ]
+  end
+
+  def line_arrivals("940GZZLUTBC", "northern") do
+    [%{"$type" => "Tfl.Api.Presentation.Entities.Prediction, Tfl.Api.Presentation.Entities",
+      "bearing" => "", "currentLocation" => "Between Moorgate and Bank",
+      "destinationName" => "Morden Underground Station",
+      "destinationNaptanId" => "940GZZLUMDN", "direction" => "inbound",
+      "expectedArrival" => "2017-02-11T09:34:50Z", "id" => "-2042375039",
+      "lineId" => "northern", "lineName" => "Northern", "modeName" => "tube",
+      "naptanId" => "940GZZLUTBC", "operationType" => 1,
+      "platformName" => "Southbound - Platform 2",
+      "stationName" => "Tooting Bec Underground Station",
+      "timeToLive" => "2017-02-11T09:34:50Z", "timeToStation" => 1367,
+      "timestamp" => "2017-02-11T09:12:03Z",
+      "timing" =>
+        %{"$type" => "Tfl.Api.Presentation.Entities.PredictionTiming, Tfl.Api.Presentation.Entities",
+          "countdownServerAdjustment" => "00:00:00",
+          "insert" => "0001-01-01T00:00:00", "read" => "2017-02-11T09:12:02.591Z",
+          "received" => "0001-01-01T00:00:00", "sent" => "2017-02-11T09:12:03Z",
+          "source" => "0001-01-01T00:00:00"}, "towards" => "Morden via Bank",
+          "vehicleId" => "262"},
+    %{"$type" => "Tfl.Api.Presentation.Entities.Prediction, Tfl.Api.Presentation.Entities",
+    "bearing" => "", "currentLocation" => "Approaching Tooting Bec",
+    "destinationName" => "High Barnet Underground Station",
+    "destinationNaptanId" => "940GZZLUHBT", "direction" => "outbound",
+    "expectedArrival" => "2017-02-11T09:12:20Z", "id" => "-35420651",
+    "lineId" => "northern", "lineName" => "Northern", "modeName" => "tube",
+    "naptanId" => "940GZZLUTBC", "operationType" => 1,
+    "platformName" => "Northbound - Platform 1",
+    "stationName" => "Tooting Bec Underground Station",
+    "timeToLive" => "2017-02-11T09:12:20Z", "timeToStation" => 17,
+    "timestamp" => "2017-02-11T09:12:03Z",
+    "timing" => %{"$type" => "Tfl.Api.Presentation.Entities.PredictionTiming, Tfl.Api.Presentation.Entities",
+      "countdownServerAdjustment" => "00:00:00",
+      "insert" => "0001-01-01T00:00:00", "read" => "2017-02-11T09:12:02.528Z",
+      "received" => "0001-01-01T00:00:00", "sent" => "2017-02-11T09:12:03Z",
+      "source" => "0001-01-01T00:00:00"}, "towards" => "High Barnet via Bank",
+      "vehicleId" => "246"},
+    %{"$type" => "Tfl.Api.Presentation.Entities.Prediction, Tfl.Api.Presentation.Entities",
+    "bearing" => "", "currentLocation" => "At Elephant and Castle Platform 2",
+    "destinationName" => "Morden Underground Station",
+    "destinationNaptanId" => "940GZZLUMDN", "direction" => "inbound",
+    "expectedArrival" => "2017-02-11T09:27:50Z", "id" => "991083851",
+    "lineId" => "northern", "lineName" => "Northern", "modeName" => "tube",
+    "naptanId" => "940GZZLUTBC", "operationType" => 1,
+    "platformName" => "Southbound - Platform 2",
+    "stationName" => "Tooting Bec Underground Station",
+    "timeToLive" => "2017-02-11T09:27:50Z", "timeToStation" => 947,
+    "timestamp" => "2017-02-11T09:12:03Z",
+    "timing" => %{"$type" => "Tfl.Api.Presentation.Entities.PredictionTiming, Tfl.Api.Presentation.Entities",
+      "countdownServerAdjustment" => "00:00:00",
+      "insert" => "0001-01-01T00:00:00", "read" => "2017-02-11T09:12:02.575Z",
+      "received" => "0001-01-01T00:00:00", "sent" => "2017-02-11T09:12:03Z",
+      "source" => "0001-01-01T00:00:00"}, "towards" => "Morden via Bank",
+      "vehicleId" => "244"},
+    %{"$type" => "Tfl.Api.Presentation.Entities.Prediction, Tfl.Api.Presentation.Entities",
+    "bearing" => "",
+    "currentLocation" => "Between Colliers Wood and Tooting Broadway",
+    "destinationName" => "Edgware Underground Station",
+    "destinationNaptanId" => "940GZZLUEGW", "direction" => "outbound",
+    "expectedArrival" => "2017-02-11T09:14:50Z", "id" => "-2040605567",
+    "lineId" => "northern", "lineName" => "Northern", "modeName" => "tube",
+    "naptanId" => "940GZZLUTBC", "operationType" => 1,
+    "platformName" => "Northbound - Platform 1",
+    "stationName" => "Tooting Bec Underground Station",
+    "timeToLive" => "2017-02-11T09:14:50Z", "timeToStation" => 167,
+    "timestamp" => "2017-02-11T09:12:03Z",
+    "timing" => %{"$type" => "Tfl.Api.Presentation.Entities.PredictionTiming, Tfl.Api.Presentation.Entities",
+      "countdownServerAdjustment" => "00:00:00",
+      "insert" => "0001-01-01T00:00:00", "read" => "2017-02-11T09:12:02.528Z",
+      "received" => "0001-01-01T00:00:00", "sent" => "2017-02-11T09:12:03Z",
+      "source" => "0001-01-01T00:00:00"}, "towards" => "Edgware via Bank",
+      "vehicleId" => "212"}]
+  end
+
+  def to_datetime(timestamp) do
+    timestamp
+    |> remove_ms
+    |> add_timezone
+    |> Timex.parse!("{ISO:Extended}")
+  end
+
+  defp remove_ms(timestamp) do
+    case String.split(timestamp, ".") do
+      [time, _ms] ->
+        time
+      [_time] ->
+        timestamp
+    end
+  end
+
+  defp add_timezone(string), do: "#{string}Z"
+
+end

--- a/lib/tfl/mock.ex
+++ b/lib/tfl/mock.ex
@@ -11,7 +11,10 @@ defmodule Commuter.Tfl.Mock do
   """
   def successful_response?(_response), do: true
 
-  def take_body(map), do: map.body
+  @doc """
+  This doesn't do anything. Just a smoke screen.
+  """
+  def take_body(list), do: list
 
   @doc """
   Returns four stations:
@@ -19,6 +22,8 @@ defmodule Commuter.Tfl.Mock do
   - Waterloo
   - Tooting Bec
   - Victoria
+
+  Returns a list of objects.
   """
   def retrieve_all_stations(_url \\ "fake") do
     IO.puts "Using Mock TFL to get station list..."
@@ -58,6 +63,9 @@ defmodule Commuter.Tfl.Mock do
     ]
   end
 
+  @doc """
+  Returns a JSON string full of train objects as if it was from TFL.
+  """
   def line_arrivals("940GZZLUTBC", "northern") do
     [%{"$type" => "Tfl.Api.Presentation.Entities.Prediction, Tfl.Api.Presentation.Entities",
       "bearing" => "", "currentLocation" => "Between Moorgate and Bank",
@@ -129,8 +137,12 @@ defmodule Commuter.Tfl.Mock do
       "received" => "0001-01-01T00:00:00", "sent" => "2017-02-11T09:12:03Z",
       "source" => "0001-01-01T00:00:00"}, "towards" => "Edgware via Bank",
       "vehicleId" => "212"}]
+      |> Poison.encode!
   end
 
+  @doc """
+  Converts timestamp strings to DateTime objects.
+  """
   def to_datetime(timestamp) do
     timestamp
     |> remove_ms

--- a/lib/tfl/station.ex
+++ b/lib/tfl/station.ex
@@ -8,7 +8,7 @@ defmodule Commuter.Tfl.Station do
   """
   use GenServer
 
-  alias Commuter.Tfl
+  @tfl_api Application.get_env(:commuter, :tfl_api)
 
   defstruct [:id, :name, :lines]
 
@@ -50,14 +50,14 @@ defmodule Commuter.Tfl.Station do
   end
 
   def handle_call({:get_arrivals, {station_id, line_id}}, _from, station_list) do
-    arrivals = Tfl.line_arrivals(station_id, line_id)
+    arrivals = @tfl_api.line_arrivals(station_id, line_id)
     {:reply, arrivals, station_list}
   end
 
   # Application set up
 
   defp create_station_list do
-    Tfl.retrieve_all_stations
+    @tfl_api.retrieve_all_stations
     |> Enum.filter( &(is_tube_station?(&1)) )
     |> Enum.map( &(convert_to_struct(&1)) )
   end
@@ -67,16 +67,6 @@ defmodule Commuter.Tfl.Station do
   defp find_station(given_id, station_list) do
     Enum.find(station_list, fn %Commuter.Tfl.Station{id: id} -> id == given_id end)
   end
-
-  # defp create_station_list(url \\ ) do
-  #   IO.puts "Calling TFL for the list of trains..."
-  #   %HTTPotion.Response{body: body} =
-  #     HTTPotion.get(url, [timeout: 50_000])
-  #   body
-  #   |> Poison.decode!
-  #   |> Enum.filter( &(is_tube_station?(&1)) )
-  #   |> Enum.map( &(convert_to_struct(&1)) )
-  # end
 
   defp is_tube_station?(map) do
     modes = map["modes"]

--- a/lib/tfl/tfl.ex
+++ b/lib/tfl/tfl.ex
@@ -49,6 +49,7 @@ defmodule Commuter.Tfl do
   in order for the app to start up) there is a checker function that retries
   an unsuccessful call.
   """
+  @callback retrieve_all_stations(url :: String.t) :: [%{}]
   def retrieve_all_stations(url \\ @tfl_all_stations) do
     IO.puts "Calling TFL for the list of stations..."
     HTTPotion.get(url, [timeout: 20_000])
@@ -58,7 +59,7 @@ defmodule Commuter.Tfl do
 
   # I am not letting this crash like I should, because this call MUST
   # succeed for the appliation server to start.
-  defp handle_response(%HTTPotion.ErrorResponse{} = res) do
+  defp handle_response(%HTTPotion.ErrorResponse{}) do
     IO.puts("The call failed!")
     retrieve_all_stations
   end
@@ -69,6 +70,7 @@ defmodule Commuter.Tfl do
   @doc """
   TODO: doc this up!
   """
+  @callback line_arrivals(station_id :: String.t, line_id :: String.t) :: String.t
   def line_arrivals(station_id, line_id) do
     "https://api.tfl.gov.uk/Line/#{line_id}/Arrivals?stopPointId=#{station_id}"
     |> call_tfl
@@ -76,8 +78,10 @@ defmodule Commuter.Tfl do
 
   # Parsing Functions
 
-  # This is a really hacky way to get around the fact that (seemingly) timestamps
-
+  @doc """
+  Converts timestamp strings to `DateTime` structs, removing milliseconds.
+  """
+  @callback to_datetime(timestamp :: String.t) :: %DateTime{}
   def to_datetime(timestamp) do
     timestamp
     |> remove_ms
@@ -89,7 +93,7 @@ defmodule Commuter.Tfl do
     case String.split(timestamp, ".") do
       [time, _ms] ->
         time
-      [time] ->
+      [_time] ->
         timestamp
     end
   end

--- a/lib/tfl/tfl.ex
+++ b/lib/tfl/tfl.ex
@@ -7,23 +7,77 @@ defmodule Commuter.Tfl do
   """
   use Timex
 
+  @tfl_all_stations "https://api.tfl.gov.uk/StopPoint/Type/NaptanMetroStation"
+
+  # Various helper functions for calling TFL and handling responses.
+
   @doc """
-  TODO: doc this up!
+  All-purpose call to TFL using an HTTP client.
+
+  Appends the app key and app ID to the url before making a get request to `url`.
   """
-  def call_station(station_id, line_id) do
-    "https://api.tfl.gov.uk/Line/#{line_id}/Arrivals?stopPointId=#{station_id}"
+  def call_tfl(url) do
+    url
+    |> add_credentials
     |> HTTPotion.get
   end
 
-  #TODO: check that HTTPotion did not return an error
+  #TODO: this should take the api key and api id from mix.env
+  defp add_credentials(url) do
+    url
+  end
 
-  # This is a really hacky way to get around the fact that (seemingly) timestamps
-  # from TFL contain TOO MANY milliseconds for Timex library to handle.
-  # :facepalm:
+  @doc """
+  Returns `true` if the response from TFL indicated success, false otherwise.
+  """
+  def successful_response?(response) do
+    HTTPotion.Response.success?(response)
+  end
+
+  @doc """
+  Helper function for grabbing only the body of an HTTP response.
+  """
+  def take_body(%HTTPotion.Response{body: body}), do: body
+
+  # Application Set Up
+
+  @doc """
+  Makes a giant call to TFL to retrieve every single station on the network.
+
+  This is a biggie, and will take A LONG TIME, which is why the timeout is so
+  hideous. Also, because this is a unique call (it has to happen successfully
+  in order for the app to start up) there is a checker function that retries
+  an unsuccessful call.
+  """
+  def retrieve_all_stations(url \\ @tfl_all_stations) do
+    IO.puts "Calling TFL for the list of stations..."
+    HTTPotion.get(url, [timeout: 20_000])
+    |> handle_response
+    |> Poison.decode!([])
+  end
+
+  # I am not letting this crash like I should, because this call MUST
+  # succeed for the appliation server to start.
+  defp handle_response(%HTTPotion.ErrorResponse{} = res) do
+    IO.puts("The call failed!")
+    retrieve_all_stations
+  end
+  defp handle_response(successful_response), do: take_body(successful_response)
+
+  # Arrival Data
 
   @doc """
   TODO: doc this up!
   """
+  def line_arrivals(station_id, line_id) do
+    "https://api.tfl.gov.uk/Line/#{line_id}/Arrivals?stopPointId=#{station_id}"
+    |> call_tfl
+  end
+
+  # Parsing Functions
+
+  # This is a really hacky way to get around the fact that (seemingly) timestamps
+
   def to_datetime(timestamp) do
     timestamp
     |> remove_ms

--- a/lib/tfl/tfl.ex
+++ b/lib/tfl/tfl.ex
@@ -54,7 +54,7 @@ defmodule Commuter.Tfl do
     IO.puts "Calling TFL for the list of stations..."
     HTTPotion.get(url, [timeout: 20_000])
     |> handle_response
-    |> Poison.decode!([])
+    |> Poison.decode!
   end
 
   # I am not letting this crash like I should, because this call MUST

--- a/test/station/station_controller_test.exs
+++ b/test/station/station_controller_test.exs
@@ -1,15 +1,57 @@
 defmodule Commuter.Station.ControllerTest do
-  use ExUnit.Case
-
+  use ExUnit.Case, async: true
+  use Plug.Test
   alias Commuter.Station.Controller
 
   @tooting "940GZZLUTBC"
   @northern "northern"
   @direction "inbound"
+  @opts Commuter.Router.init([])
 
-  test "returns a list of train structs" do
-    result = Controller.return_arrivals(@tooting, @northern, @direction)
-    assert is_list(result)
-    
+  # test "returns OK from homepage" do
+  #   #create a test connection
+  #   conn = conn(:get, "/")
+  #
+  #   #invoke the plug
+  #   conn = Commuter.Router.call(conn, @opts)
+  #
+  #   #assert the response and the status
+  #   assert conn.state == :sent
+  #   assert conn.status == 200
+  #   assert conn.resp_body == "OK"
+  # end
+
+  setup do
+    bad_resp =
+      conn(:get, "/stations/940GZZFAKE/northern/outbound")
+      |> Commuter.Router.call(@opts)
+      |> Controller.get_arrivals
+    good_resp =
+      conn(:get, "stations/940GZZLUTBC/northern/outbound")
+      |> Commuter.Router.call(@opts)
+      |> Controller.get_arrivals
+    %{responses: %{bad_resp: bad_resp, good_resp: good_resp}}
   end
+
+  test "returns 404 if there was not a running station process",
+  %{responses: %{bad_resp: resp}} do
+    assert resp.status == 404
+    assert resp.resp_body == "NOT FOUND"
+  end
+
+  test "returns 200 and json if there was a running station process",
+  %{responses: %{good_resp: resp}} do
+    assert resp.status == 200
+    assert is_binary(resp.resp_body)
+  end
+
+  test "puts the potential process id and direction into Conn",
+  %{responses: responses} do
+    assigns =
+      Enum.map(responses, fn {_k,m} -> Enum.into(m.assigns, []) end)
+      |> List.flatten
+    Enum.each(assigns, fn {_k,v} -> assert is_atom(v) end)
+  end
+
+
 end

--- a/test/station/station_test.exs
+++ b/test/station/station_test.exs
@@ -2,10 +2,6 @@ defmodule Commuter.Station.StationTest do
   use ExUnit.Case, async: true
   alias Commuter.Station
 
-  @tooting "940GZZLUTBC"
-  @northern "northern"
-  @direction "inbound"
-
   @process_id :"940GZZLUTBC_northern"
 
   test "returns a struct with two lists of trains" do


### PR DESCRIPTION
This PR was after reading this article by Jose Valim:

http://blog.plataformatec.com.br/2015/10/mocks-and-explicit-contracts/

The need was: I want to be able to test this properly without constantly calling TFL's api.

To do this, I've created a Mock version of the TFL api and moved some things around to allow me to call the Mock/real TFL API dependent on the `Mix.env` variable.

I've also tried to reduce the surface area of the API module, to standardise any calls made to the API.