### PR TITLE
Prep HEROKU deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ erl_crash.dump
 *.ez
 
 *.DS_Store
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,3 +1,5 @@
 use Mix.Config
 
 config :commuter, :tfl_api, Commuter.Tfl
+config :commuter,
+  server: true

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,0 +1,5 @@
+# Erlang version
+erlang_version=18.2.1
+
+# Elixir version
+elixir_version=1.4.0

--- a/lib/tfl/tfl.ex
+++ b/lib/tfl/tfl.ex
@@ -52,7 +52,7 @@ defmodule Commuter.Tfl do
   @callback retrieve_all_stations(url :: String.t) :: [%{}]
   def retrieve_all_stations(url \\ @tfl_all_stations) do
     IO.puts "Calling TFL for the list of stations..."
-    HTTPotion.get(url, [timeout: 20_000])
+    HTTPotion.get(url, [timeout: 50_000])
     |> handle_response
     |> Poison.decode!
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Commuter.Mixfile do
   def project do
     [app: :commuter,
      version: "0.1.0",
-     elixir: "~> 1.3",
+     elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps()]

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -28,7 +28,7 @@ environment :dev do
 end
 
 environment :prod do
-  set include_erts: false
+  # set include_erts: false
   set include_src: false
   set cookie: :"@8p&W@PKUr8YwHC|1BNu~k/C2K26_2<itcM@z8]mDXRh/ffa,*I4buI*$)5qYbzL"
 end


### PR DESCRIPTION
preps for deployment to Heroku platform.

NB: this isn't actually handling deployment in a proper manner, it's just to get it up and running for test. (ie: it doesn't really use distillery, or releases as such. It just deploys it to heroku)